### PR TITLE
Add Support for Custom Python Binary Path

### DIFF
--- a/defaults/python/lib/constants.py
+++ b/defaults/python/lib/constants.py
@@ -15,7 +15,7 @@ def get_user():
 
 CURRENT_USER = get_user()
 BUDDY_API_VERSION = 4
-CONFIG_VERSION_LITERAL = typing.Literal[23]
+CONFIG_VERSION_LITERAL = typing.Literal[24]
 CONFIG_DIR = str(pathlib.Path("/home", CURRENT_USER, ".config", "moondeck"))
 CONFIG_FILENAME = "settings.json"
 LOG_FILE = "/tmp/moondeck.log"

--- a/defaults/python/lib/settings.py
+++ b/defaults/python/lib/settings.py
@@ -108,7 +108,6 @@ class UserSettings(TypedDict):
     runnerDebugLogs: bool
     useMoonlightExec: bool
     moonlightExecPath: str
-    usePythonExec: bool
     pythonExecPath: str
 
 
@@ -165,7 +164,6 @@ class SettingsManager:
                 "runnerDebugLogs": False,
                 "useMoonlightExec": False,
                 "moonlightExecPath": "",
-                "usePythonExec": False,
                 "pythonExecPath": ""
                 }))
 
@@ -297,7 +295,6 @@ class SettingsManager:
                 data["hostSettings"][host]["sunshineApps"]["lastSelectedControllerConfig"] = "Noop"
         if data["version"] == 23:
             data["version"] = 24
-            data["usePythonExec"] = False
             data["pythonExecPath"] = ""
         return data
 

--- a/defaults/python/lib/settings.py
+++ b/defaults/python/lib/settings.py
@@ -164,8 +164,7 @@ class SettingsManager:
                 "runnerDebugLogs": False,
                 "useMoonlightExec": False,
                 "moonlightExecPath": "",
-                "pythonExecPath": ""
-                }))
+                "pythonExecPath": ""}))
 
     async def set(self, settings: UserSettings):
         try:

--- a/defaults/python/lib/settings.py
+++ b/defaults/python/lib/settings.py
@@ -108,6 +108,8 @@ class UserSettings(TypedDict):
     runnerDebugLogs: bool
     useMoonlightExec: bool
     moonlightExecPath: str
+    usePythonExec: bool
+    pythonExecPath: str
 
 
 class SettingsManager:
@@ -162,7 +164,10 @@ class SettingsManager:
                 "hostSettings": {},
                 "runnerDebugLogs": False,
                 "useMoonlightExec": False,
-                "moonlightExecPath": ""}))
+                "moonlightExecPath": "",
+                "usePythonExec": False,
+                "pythonExecPath": ""
+                }))
 
     async def set(self, settings: UserSettings):
         try:
@@ -290,7 +295,10 @@ class SettingsManager:
             data["gameSession"]["controllerConfig"] = "Noop"
             for host in data["hostSettings"].keys():
                 data["hostSettings"][host]["sunshineApps"]["lastSelectedControllerConfig"] = "Noop"
-
+        if data["version"] == 23:
+            data["version"] = 24
+            data["usePythonExec"] = False
+            data["pythonExecPath"] = ""
         return data
 
 

--- a/defaults/python/moondeckrun.sh
+++ b/defaults/python/moondeckrun.sh
@@ -4,4 +4,4 @@
 CURRENT_DIR=`dirname "$(readlink -f "$0")"`
 cd "$CURRENT_DIR";
 
-exec /usr/bin/python ./runner.py
+exec ${MOONLIGHT_PYTHON:-/usr/bin/python} ./runner.py

--- a/defaults/python/moondeckrun.sh
+++ b/defaults/python/moondeckrun.sh
@@ -4,4 +4,4 @@
 CURRENT_DIR=`dirname "$(readlink -f "$0")"`
 cd "$CURRENT_DIR";
 
-exec ${MOONLIGHT_PYTHON:-/usr/bin/python} ./runner.py
+exec ${MOONDECK_PYTHON:-/usr/bin/python} ./runner.py

--- a/src/components/changelogview/changelogview.tsx
+++ b/src/components/changelogview/changelogview.tsx
@@ -6,6 +6,11 @@ export const ChangelogView: VFC<unknown> = () => {
     <DialogBody>
       <DialogControlsSection>
         <Field
+          label="1.8.3"
+          description="Added python executable path override for moondeck runner."
+          focusable={true}
+        />
+        <Field
           label="1.8.2"
           description="Fixed exception (introduced with 1.8.1) when a fresh settings file is being created."
           focusable={true}

--- a/src/components/runnersettingsview/pythonexecutablesection.tsx
+++ b/src/components/runnersettingsview/pythonexecutablesection.tsx
@@ -2,17 +2,15 @@ import { DialogButton, Field, Focusable } from "@decky/ui";
 import { FilePickerRes, FileSelectionType, openFilePicker } from "@decky/api";
 import { SettingsManager, logger } from "../../lib";
 import { AnyTextInput } from "../shared";
+import { VFC } from "react";
 import { useCurrentSettings } from "../../hooks";
 
 interface Props {
   settingsManager: SettingsManager;
 }
 
-export const PythonExecutableSection: React.FC<Props> = ({
-  settingsManager
-}) => {
+export const PythonExecutableSection: VFC<Props> = ({ settingsManager }) => {
   const userSettings = useCurrentSettings(settingsManager);
-
   if (userSettings === null) {
     return null;
   }
@@ -46,7 +44,7 @@ export const PythonExecutableSection: React.FC<Props> = ({
 
   return (
     <Field
-      description="Some distros ship with Python without tkinter, which is required for the runner to work. You can install Python via homebrw and link it here."
+      description="Some immutable distros ship with Python without tkinter, which is required for the runner to work. You can install Python via homebrew and link it here."
       childrenContainerWidth="max"
       childrenLayout="below"
     >

--- a/src/components/runnersettingsview/pythonexecutablesection.tsx
+++ b/src/components/runnersettingsview/pythonexecutablesection.tsx
@@ -1,0 +1,90 @@
+import { AnyTextInput, ToggleField } from "../shared";
+import { DialogButton, Field, Focusable } from "@decky/ui";
+import { FilePickerRes, FileSelectionType, openFilePicker } from "@decky/api";
+import { SettingsManager, logger } from "../../lib";
+import { useCurrentSettings } from "../../hooks";
+
+interface Props {
+  settingsManager: SettingsManager;
+}
+
+export const PythonExecutableSection: React.FC<Props> = ({
+  settingsManager
+}) => {
+  const userSettings = useCurrentSettings(settingsManager);
+
+  if (userSettings === null) {
+    return null;
+  }
+
+  const browseForExec = (): void => {
+    settingsManager
+      .getHomeDir()
+      .then((homeDir): Promise<FilePickerRes> | null => {
+        if (homeDir !== null) {
+          return openFilePicker(
+            FileSelectionType.FILE,
+            `${homeDir}`,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            true
+          );
+        }
+        return null;
+      })
+      .then((result) => {
+        if (result !== null) {
+          settingsManager.update((userSettings) => {
+            userSettings.pythonExecPath = result.realpath;
+          });
+        }
+      })
+      .catch((error) => logger.error(error));
+  };
+
+  return (
+    <>
+      <ToggleField
+        label="Use custom Python executable"
+        description="Some distros ship with Python without tkinter, which is required for the runner to work. You can install Python via homebrw and link it here."
+        bottomSeparator="none"
+        value={userSettings.usePythonExec}
+        setValue={(value) =>
+          settingsManager.update((userSettings) => {
+            userSettings.usePythonExec = value;
+          })
+        }
+      />
+
+      <Field childrenContainerWidth="max" childrenLayout="below">
+        <Focusable
+          style={{
+            display: "grid",
+            gap: "10px",
+            gridTemplateColumns: "1fr auto"
+          }}
+        >
+          <AnyTextInput
+            disabled={!userSettings.usePythonExec}
+            value={userSettings.pythonExecPath}
+            setValue={(value) =>
+              settingsManager.update((userSettings) => {
+                userSettings.pythonExecPath = value;
+              })
+            }
+          />
+          <DialogButton
+            style={{ minWidth: "initial", width: "initial" }}
+            disabled={!userSettings.usePythonExec}
+            focusable={userSettings.usePythonExec}
+            onClick={() => browseForExec()}
+          >
+            Browse
+          </DialogButton>
+        </Focusable>
+      </Field>
+    </>
+  );
+};

--- a/src/components/runnersettingsview/pythonexecutablesection.tsx
+++ b/src/components/runnersettingsview/pythonexecutablesection.tsx
@@ -1,7 +1,7 @@
-import { AnyTextInput, ToggleField } from "../shared";
 import { DialogButton, Field, Focusable } from "@decky/ui";
 import { FilePickerRes, FileSelectionType, openFilePicker } from "@decky/api";
 import { SettingsManager, logger } from "../../lib";
+import { AnyTextInput } from "../shared";
 import { useCurrentSettings } from "../../hooks";
 
 interface Props {
@@ -24,7 +24,7 @@ export const PythonExecutableSection: React.FC<Props> = ({
         if (homeDir !== null) {
           return openFilePicker(
             FileSelectionType.FILE,
-            `${homeDir}`,
+            "/",
             undefined,
             undefined,
             undefined,
@@ -45,46 +45,33 @@ export const PythonExecutableSection: React.FC<Props> = ({
   };
 
   return (
-    <>
-      <ToggleField
-        label="Use custom Python executable"
-        description="Some distros ship with Python without tkinter, which is required for the runner to work. You can install Python via homebrw and link it here."
-        bottomSeparator="none"
-        value={userSettings.usePythonExec}
-        setValue={(value) =>
-          settingsManager.update((userSettings) => {
-            userSettings.usePythonExec = value;
-          })
-        }
-      />
-
-      <Field childrenContainerWidth="max" childrenLayout="below">
-        <Focusable
-          style={{
-            display: "grid",
-            gap: "10px",
-            gridTemplateColumns: "1fr auto"
-          }}
+    <Field
+      description="Some distros ship with Python without tkinter, which is required for the runner to work. You can install Python via homebrw and link it here."
+      childrenContainerWidth="max"
+      childrenLayout="below"
+    >
+      <Focusable
+        style={{
+          display: "grid",
+          gap: "10px",
+          gridTemplateColumns: "1fr auto"
+        }}
+      >
+        <AnyTextInput
+          value={userSettings.pythonExecPath}
+          setValue={(value) =>
+            settingsManager.update((userSettings) => {
+              userSettings.pythonExecPath = value;
+            })
+          }
+        />
+        <DialogButton
+          style={{ minWidth: "initial", width: "initial" }}
+          onClick={() => browseForExec()}
         >
-          <AnyTextInput
-            disabled={!userSettings.usePythonExec}
-            value={userSettings.pythonExecPath}
-            setValue={(value) =>
-              settingsManager.update((userSettings) => {
-                userSettings.pythonExecPath = value;
-              })
-            }
-          />
-          <DialogButton
-            style={{ minWidth: "initial", width: "initial" }}
-            disabled={!userSettings.usePythonExec}
-            focusable={userSettings.usePythonExec}
-            onClick={() => browseForExec()}
-          >
-            Browse
-          </DialogButton>
-        </Focusable>
-      </Field>
-    </>
+          Browse
+        </DialogButton>
+      </Focusable>
+    </Field>
   );
 };

--- a/src/components/runnersettingsview/runnersettingsview.tsx
+++ b/src/components/runnersettingsview/runnersettingsview.tsx
@@ -3,6 +3,7 @@ import { LabelWithIcon, NumericTextInput, ToggleField } from "../shared";
 import { SettingsManager, appLaunchDefault, appLaunchStabilityDefault, appUpdateDefault, buddyRequestsDefault, initialConditionsDefault, networkReconnectAfterSuspendDefault, servicePingDefault, steamLaunchAfterSuspendDefault, steamLaunchDefault, streamEndDefault, streamReadinessDefault, wakeOnLanDefault } from "../../lib";
 import { useCurrentHostSettings, useCurrentSettings } from "../../hooks";
 import { HostOff } from "../icons";
+import { PythonExecutableSection } from "./pythonexecutablesection";
 import { VFC } from "react";
 
 interface Props {
@@ -34,6 +35,7 @@ export const RunnerSettingsView: VFC<Props> = ({ settingsManager }) => {
           value={userSettings.runnerDebugLogs}
           setValue={(value) => settingsManager.update((userSettings) => { userSettings.runnerDebugLogs = value; })}
         />
+        <PythonExecutableSection settingsManager={settingsManager} />
       </DialogControlsSection>
       <DialogControlsSection>
         <DialogControlsSectionHeader>Timeouts</DialogControlsSectionHeader>

--- a/src/lib/moondeckapplauncher.ts
+++ b/src/lib/moondeckapplauncher.ts
@@ -278,10 +278,9 @@ export class MoonDeckAppLauncher {
           return;
         }
 
-        const pythonPath = this.settingsManager.settings.value?.pythonExecPath ?? null;
-        const usePythonExec = this.settingsManager.settings.value?.usePythonExec ?? false;
+        const pythonPath = this.settingsManager.settings.value?.pythonExecPath ?? "";
 
-        const launchOptions = `${getMoonDeckAppIdMark(appId)}${getMoonDeckResMark(mode, hostSettings.resolution.automatic)}${getMoonDeckLinkedDisplayMark(currentDisplay)}${getMoonDeckPython(pythonPath, usePythonExec)} %command%`;
+        const launchOptions = `${getMoonDeckAppIdMark(appId)}${getMoonDeckResMark(mode, hostSettings.resolution.automatic)}${getMoonDeckLinkedDisplayMark(currentDisplay)}${getMoonDeckPython(pythonPath)} %command%`;
         if (!await setAppLaunchOptions(details.unAppID, launchOptions)) {
           logger.toast("Failed to update shortcut launch options (needs restart?)!", { output: "error" });
           return;

--- a/src/lib/moondeckapplauncher.ts
+++ b/src/lib/moondeckapplauncher.ts
@@ -1,4 +1,4 @@
-import { ControllerConfigOption, SteamClientEx, getAppDetails, getCurrentDisplayModeString, getDisplayIdentifiers, getMoonDeckAppIdMark, getMoonDeckLinkedDisplayMark, getMoonDeckResMark, getSystemNetworkStore, launchApp, registerForGameLifetime, registerForSuspendNotifictions, setAppHiddenState, setAppLaunchOptions, setAppResolutionOverride, setShortcutName, waitForNetworkConnection } from "./steamutils";
+import { ControllerConfigOption, SteamClientEx, getAppDetails, getCurrentDisplayModeString, getDisplayIdentifiers, getMoonDeckAppIdMark, getMoonDeckLinkedDisplayMark, getMoonDeckPython, getMoonDeckResMark, getSystemNetworkStore, launchApp, registerForGameLifetime, registerForSuspendNotifictions, setAppHiddenState, setAppLaunchOptions, setAppResolutionOverride, setShortcutName, waitForNetworkConnection } from "./steamutils";
 import { ControllerConfigValues, Dimension, HostResolution, HostSettings, SettingsManager, networkReconnectAfterSuspendDefault } from "./settingsmanager";
 import { E_ALREADY_LOCKED, Mutex, tryAcquire } from "async-mutex";
 import { Subscription, pairwise } from "rxjs";
@@ -278,7 +278,10 @@ export class MoonDeckAppLauncher {
           return;
         }
 
-        const launchOptions = `${getMoonDeckAppIdMark(appId)}${getMoonDeckResMark(mode, hostSettings.resolution.automatic)}${getMoonDeckLinkedDisplayMark(currentDisplay)} %command%`;
+        const pythonPath = this.settingsManager.settings.value?.pythonExecPath ?? null;
+        const usePythonExec = this.settingsManager.settings.value?.usePythonExec ?? false;
+
+        const launchOptions = `${getMoonDeckAppIdMark(appId)}${getMoonDeckResMark(mode, hostSettings.resolution.automatic)}${getMoonDeckLinkedDisplayMark(currentDisplay)}${getMoonDeckPython(pythonPath, usePythonExec)} %command%`;
         if (!await setAppLaunchOptions(details.unAppID, launchOptions)) {
           logger.toast("Failed to update shortcut launch options (needs restart?)!", { output: "error" });
           return;

--- a/src/lib/moondeckapplauncher.ts
+++ b/src/lib/moondeckapplauncher.ts
@@ -1,4 +1,4 @@
-import { ControllerConfigOption, SteamClientEx, getAppDetails, getCurrentDisplayModeString, getDisplayIdentifiers, getMoonDeckAppIdMark, getMoonDeckLinkedDisplayMark, getMoonDeckPython, getMoonDeckResMark, getSystemNetworkStore, launchApp, registerForGameLifetime, registerForSuspendNotifictions, setAppHiddenState, setAppLaunchOptions, setAppResolutionOverride, setShortcutName, waitForNetworkConnection } from "./steamutils";
+import { ControllerConfigOption, SteamClientEx, getAppDetails, getCurrentDisplayModeString, getDisplayIdentifiers, getMoonDeckAppIdMark, getMoonDeckLinkedDisplayMark, getMoonDeckPythonMark, getMoonDeckResMark, getSystemNetworkStore, launchApp, registerForGameLifetime, registerForSuspendNotifictions, setAppHiddenState, setAppLaunchOptions, setAppResolutionOverride, setShortcutName, waitForNetworkConnection } from "./steamutils";
 import { ControllerConfigValues, Dimension, HostResolution, HostSettings, SettingsManager, networkReconnectAfterSuspendDefault } from "./settingsmanager";
 import { E_ALREADY_LOCKED, Mutex, tryAcquire } from "async-mutex";
 import { Subscription, pairwise } from "rxjs";
@@ -280,7 +280,7 @@ export class MoonDeckAppLauncher {
 
         const pythonPath = this.settingsManager.settings.value?.pythonExecPath ?? "";
 
-        const launchOptions = `${getMoonDeckAppIdMark(appId)}${getMoonDeckResMark(mode, hostSettings.resolution.automatic)}${getMoonDeckLinkedDisplayMark(currentDisplay)}${getMoonDeckPython(pythonPath)} %command%`;
+        const launchOptions = `${getMoonDeckAppIdMark(appId)}${getMoonDeckResMark(mode, hostSettings.resolution.automatic)}${getMoonDeckLinkedDisplayMark(currentDisplay)}${getMoonDeckPythonMark(pythonPath)} %command%`;
         if (!await setAppLaunchOptions(details.unAppID, launchOptions)) {
           logger.toast("Failed to update shortcut launch options (needs restart?)!", { output: "error" });
           return;

--- a/src/lib/moondeckapplauncher.ts
+++ b/src/lib/moondeckapplauncher.ts
@@ -218,7 +218,7 @@ export class MoonDeckAppLauncher {
       return;
     }
 
-    const settings = this.settingsManager.settings.value?.gameSession ?? null;
+    const settings = this.settingsManager.settings.value;
     if (settings === null) {
       logger.toast("Settings are not available!", { output: "error" });
       return;
@@ -278,20 +278,18 @@ export class MoonDeckAppLauncher {
           return;
         }
 
-        const pythonPath = this.settingsManager.settings.value?.pythonExecPath ?? "";
-
-        const launchOptions = `${getMoonDeckAppIdMark(appId)}${getMoonDeckResMark(mode, hostSettings.resolution.automatic)}${getMoonDeckLinkedDisplayMark(currentDisplay)}${getMoonDeckPythonMark(pythonPath)} %command%`;
+        const launchOptions = `${getMoonDeckAppIdMark(appId)}${getMoonDeckResMark(mode, hostSettings.resolution.automatic)}${getMoonDeckLinkedDisplayMark(currentDisplay)}${getMoonDeckPythonMark(settings.pythonExecPath)} %command%`;
         if (!await setAppLaunchOptions(details.unAppID, launchOptions)) {
           logger.toast("Failed to update shortcut launch options (needs restart?)!", { output: "error" });
           return;
         }
 
-        updateControllerConfig(details.unAppID, settings.controllerConfig);
+        updateControllerConfig(details.unAppID, settings.gameSession.controllerConfig);
 
         let sessionOptions = this.moonDeckApp.value?.sessionOptions ?? null;
         if (sessionOptions === null) {
           sessionOptions = {
-            nameSetToAppId: settings.autoApplyAppId
+            nameSetToAppId: settings.gameSession.autoApplyAppId
           };
         }
 

--- a/src/lib/settingsmanager.ts
+++ b/src/lib/settingsmanager.ts
@@ -134,6 +134,8 @@ export interface UserSettings {
   runnerDebugLogs: boolean;
   useMoonlightExec: boolean;
   moonlightExecPath: string;
+  usePythonExec: boolean;
+  pythonExecPath: string;
 }
 
 export function stringifyDimension(value: Dimension): string {

--- a/src/lib/settingsmanager.ts
+++ b/src/lib/settingsmanager.ts
@@ -134,7 +134,6 @@ export interface UserSettings {
   runnerDebugLogs: boolean;
   useMoonlightExec: boolean;
   moonlightExecPath: string;
-  usePythonExec: boolean;
   pythonExecPath: string;
 }
 

--- a/src/lib/steamutils.ts
+++ b/src/lib/steamutils.ts
@@ -45,6 +45,15 @@ export function getMoonDeckAppIdMark(appId: number | null): string {
   return `${mark}=${appId}`;
 }
 
+export function getMoonDeckPython(path: string | null, useMoonlightExec: boolean): string {
+  const mark = "MOONDECK_PYTHON";
+  if (path === null || !useMoonlightExec) {
+    return mark;
+  }
+
+  return `${mark}="${path}"`;
+}
+
 export function getAppIdFromShortcut(value: string): number | null {
   const regex = new RegExp(`(?:${getMoonDeckAppIdMark(null)}=(?<steamAppId>\\d+))`, "gi");
   const matches = value.matchAll(regex);

--- a/src/lib/steamutils.ts
+++ b/src/lib/steamutils.ts
@@ -45,13 +45,13 @@ export function getMoonDeckAppIdMark(appId: number | null): string {
   return `${mark}=${appId}`;
 }
 
-export function getMoonDeckPython(path: string | null, useMoonlightExec: boolean): string {
+export function getMoonDeckPython(path: string): string {
   const mark = "MOONDECK_PYTHON";
-  if (path === null || !useMoonlightExec) {
-    return mark;
+  if (path.trim().length === 0) {
+    return "";
   }
 
-  return `${mark}="${path}"`;
+  return ` ${mark}="${path}"`;
 }
 
 export function getAppIdFromShortcut(value: string): number | null {

--- a/src/lib/steamutils.ts
+++ b/src/lib/steamutils.ts
@@ -45,7 +45,7 @@ export function getMoonDeckAppIdMark(appId: number | null): string {
   return `${mark}=${appId}`;
 }
 
-export function getMoonDeckPython(path: string): string {
+export function getMoonDeckPythonMark(path: string): string {
   const mark = "MOONDECK_PYTHON";
   if (path.trim().length === 0) {
     return "";


### PR DESCRIPTION
Description:
This change adds the option to provide a custom path for the Python binary. Some distributions, like Bazzite 41 on the ROG Ally X, don’t include tkinter by default. With this, users can install their own Python version with the required components and easily link it to Moondeck.

Testing:
Tested on a ROG Ally X running Bazzite 41 and works as expected.