### PR TITLE
Add support for linking existing Non-Steam shortcuts

### DIFF
--- a/src/components/linkednonsteamappsview/index.ts
+++ b/src/components/linkednonsteamappsview/index.ts
@@ -1,0 +1,1 @@
+export * from "./linkednonsteamappsview";

--- a/src/components/linkednonsteamappsview/linkednonsteamappsview.tsx
+++ b/src/components/linkednonsteamappsview/linkednonsteamappsview.tsx
@@ -1,0 +1,136 @@
+import { DialogBody, DialogButton, DialogControlsSection, DialogControlsSectionHeader, Field, Focusable, showModal } from "@decky/ui";
+import { FC, useContext, useState } from "react";
+import { LinkGameStreamAppModal } from "../moondecklaunchbutton/linkgamestreamappmodal";
+import type { LinkedAppShortcutInfo } from "../../lib/linkedappshortcuts";
+import { MoonDeckContext } from "../../contexts";
+import { logger } from "../../lib";
+
+export const LinkedNonSteamAppsView: FC = () => {
+  const { linkedAppShortcuts } = useContext(MoonDeckContext);
+  const [linkEntries, setLinkEntries] = useState<LinkedAppShortcutInfo[]>(
+    linkedAppShortcuts.getEntries()
+  );
+  const [pendingSourceAppId, setPendingSourceAppId] = useState<number | null>(null);
+  const [confirmingSourceAppId, setConfirmingSourceAppId] = useState<number | null>(null);
+
+  const refreshLinks = (): void => {
+    setLinkEntries(linkedAppShortcuts.getEntries());
+  };
+
+  const handleChangeLink = (
+    sourceAppId: number,
+    sourceAppName: string,
+    targetName: string
+  ): void => {
+    const Content: FC<{ closeModal?: () => void }> = ({ closeModal }) => (
+      <LinkGameStreamAppModal
+        closeModal={() => closeModal?.()}
+        sourceAppId={sourceAppId}
+        sourceAppName={sourceAppName}
+        initialTargetName={targetName}
+        onSaved={refreshLinks}
+      />
+    );
+
+    showModal(<Content />);
+  };
+
+  const handleUnlink = (sourceAppId: number): void => {
+    setPendingSourceAppId(sourceAppId);
+
+    const unlink = async (): Promise<void> => {
+      const helperAppId = linkedAppShortcuts.getId(sourceAppId);
+      if (helperAppId === null) {
+        refreshLinks();
+        return;
+      }
+
+      if (!await linkedAppShortcuts.removeShortcut(helperAppId)) {
+        logger.toast("Failed to remove linked shortcut!", { output: "error" });
+        return;
+      }
+
+      refreshLinks();
+    };
+
+    unlink()
+      .catch((e) => logger.critical(e))
+      .finally(() => {
+        setPendingSourceAppId(null);
+        setConfirmingSourceAppId(null);
+      });
+  };
+
+  return (
+    <DialogBody>
+      <DialogControlsSection>
+        <DialogControlsSectionHeader>What are Linked Non-Steam Apps?</DialogControlsSectionHeader>
+        <Field
+          description={
+            <>
+              <div>These are existing Non-Steam shortcuts linked to GameStream host apps.</div>
+              <div>Steam Play continues to launch the local shortcut. MoonDeck launches the linked host app.</div>
+            </>
+          }
+          focusable={true}
+        />
+      </DialogControlsSection>
+
+      <DialogControlsSection>
+        <DialogControlsSectionHeader>Linked Non-Steam Apps</DialogControlsSectionHeader>
+        {
+          linkEntries.length === 0 ?
+              <Field
+                label="No linked Non-Steam apps"
+                description="Create a link with the MoonDeck button on a Non-Steam shortcut."
+                focusable={true}
+              /> :
+              linkEntries.map((entry) => {
+                const pending = pendingSourceAppId === entry.sourceAppId;
+                const confirming = confirmingSourceAppId === entry.sourceAppId;
+
+                return (
+                  <Field
+                    key={entry.sourceAppId}
+                    label={entry.sourceName}
+                    description={"Host app: " + entry.targetName}
+                    childrenLayout="below"
+                    childrenContainerWidth="max"
+                  >
+                    <Focusable style={{ display: "flex", gap: "8px" }}>
+                      <DialogButton
+                        disabled={pending}
+                        onClick={() => handleChangeLink(entry.sourceAppId, entry.sourceName, entry.targetName)}
+                      >
+                        Change link
+                      </DialogButton>
+                      <DialogButton
+                        disabled={pending}
+                        onClick={() => {
+                          if (confirming) {
+                            handleUnlink(entry.sourceAppId);
+                          } else {
+                            setConfirmingSourceAppId(entry.sourceAppId);
+                          }
+                        }}
+                      >
+                        {confirming ? "Confirm unlink" : "Unlink"}
+                      </DialogButton>
+                      {
+                        confirming &&
+                        <DialogButton
+                          disabled={pending}
+                          onClick={() => setConfirmingSourceAppId(null)}
+                        >
+                          Cancel
+                        </DialogButton>
+                      }
+                    </Focusable>
+                  </Field>
+                );
+              })
+        }
+      </DialogControlsSection>
+    </DialogBody>
+  );
+};

--- a/src/components/moondecklaunchbutton/linkgamestreamappmodal.tsx
+++ b/src/components/moondecklaunchbutton/linkgamestreamappmodal.tsx
@@ -1,0 +1,100 @@
+import { DialogButton, Field, ModalRoot } from "@decky/ui";
+import { FC, useContext, useEffect, useState } from "react";
+import { getMoonDeckRunPath, logger } from "../../lib";
+import { ListDropdown } from "../shared";
+import { MoonDeckContext } from "../../contexts";
+
+interface Props {
+  closeModal: () => void;
+  sourceAppId: number;
+  sourceAppName: string;
+  initialTargetName?: string | null;
+  onSaved?: () => void;
+}
+
+export const LinkGameStreamAppModal: FC<Props> = ({
+  closeModal,
+  sourceAppId,
+  sourceAppName,
+  initialTargetName = null,
+  onSaved
+}) => {
+  const { connectivityManager, linkedAppShortcuts } = useContext(MoonDeckContext);
+  const [appNames, setAppNames] = useState<string[]>([]);
+  const [targetName, setTargetName] = useState<string | null>(initialTargetName);
+  const [savePending, setSavePending] = useState(false);
+
+  useEffect(() => {
+    connectivityManager.buddyProxy.getGameStreamAppNames()
+      .then((names) => setAppNames(names ?? []))
+      .catch((e) => logger.critical(e));
+  }, []);
+
+  const handleClick = (): void => {
+    if (targetName === null) {
+      return;
+    }
+
+    setSavePending(true);
+    const saveLink = async (): Promise<void> => {
+      const existingHelperAppId = linkedAppShortcuts.getId(sourceAppId);
+
+      if (existingHelperAppId === null) {
+        const execPath = await getMoonDeckRunPath();
+        if (execPath === null) {
+          return;
+        }
+
+        const helperAppId = await linkedAppShortcuts.addGameStreamShortcut(
+          sourceAppId,
+          sourceAppName,
+          targetName,
+          execPath
+        );
+        if (helperAppId === null) {
+          return;
+        }
+      } else {
+        if (!await linkedAppShortcuts.updateGameStreamShortcut(sourceAppId, targetName)) {
+          logger.toast("Failed to change linked host app!", { output: "error" });
+          return;
+        }
+      }
+
+      onSaved?.();
+      closeModal();
+    };
+
+    saveLink()
+      .catch((e) => logger.critical(e))
+      .finally(() => setSavePending(false));
+  };
+
+  return (
+    <ModalRoot closeModal={closeModal}>
+      <Field
+        childrenLayout="below"
+        childrenContainerWidth="max"
+        bottomSeparator="none"
+      >
+        <ListDropdown
+          label="Select host app"
+          optionList={appNames}
+          singleItemSelection={true}
+          stringifySimpleLabels={false}
+          value={targetName}
+          setValue={setTargetName}
+        />
+      </Field>
+      <Field
+        childrenLayout="below"
+        childrenContainerWidth="max"
+        bottomSeparator="none"
+      >
+        <DialogButton disabled={targetName === null || savePending} onClick={handleClick}>
+          {initialTargetName === null ? "Save link" : "Change link"}
+        </DialogButton>
+      </Field>
+    </ModalRoot>
+  );
+};

--- a/src/components/moondecklaunchbutton/moondecklaunchbutton.tsx
+++ b/src/components/moondecklaunchbutton/moondecklaunchbutton.tsx
@@ -1,10 +1,11 @@
-import { AppType, UserSettings, isAppTypeSupported, logger } from "../../lib";
+import { AppType, UserSettings, isAppTypeSupported, isNonSteamShortcut, logger } from "../../lib";
 import { Button, Focusable, appDetailsClasses, appDetailsHeaderClasses, basicAppDetailsSectionStylerClasses, joinClassNames, playSectionClasses, showModal, sleep } from "@decky/ui";
 import { CSSProperties, FC, useContext, useEffect, useRef, useState } from "react";
 import { OffsetStyle, achorPositionName } from "./offsetstyle";
 import { ButtonStyle } from "./buttonstyle";
 import { ContainerStyle } from "./containerstyle";
 import { LaunchPromptModal } from "./launchpromptmodal";
+import { LinkGameStreamAppModal } from "./linkgamestreamappmodal";
 import { MoonDeckContext } from "../../contexts";
 import { MoonDeckMain } from "../icons";
 import { useCurrentSettings } from "../../hooks";
@@ -53,10 +54,11 @@ export const MoonDeckLaunchButtonShell: FC<ShellProps> = ({ onClick, buttonPosit
 };
 
 const MoonDeckLaunchButton: FC<Props> = ({ appId, appName, appType }) => {
-  const { moonDeckAppLauncher } = useContext(MoonDeckContext);
+  const { linkedAppShortcuts, moonDeckAppLauncher } = useContext(MoonDeckContext);
   const settings = useCurrentSettings();
+  const nonSteamShortcut = isNonSteamShortcut(appType);
 
-  if (!isAppTypeSupported(appType) || settings === null) {
+  if ((!isAppTypeSupported(appType) && !nonSteamShortcut) || settings === null) {
     return null;
   }
 
@@ -65,8 +67,18 @@ const MoonDeckLaunchButton: FC<Props> = ({ appId, appName, appType }) => {
       buttonPosition={settings.buttonPosition}
       buttonStyle={settings.buttonStyle}
       onClick={(onDone: () => void) => {
+        const helperAppId = nonSteamShortcut ? linkedAppShortcuts.getId(appId) : null;
+        if (nonSteamShortcut && helperAppId === null) {
+          showModal(<LinkGameStreamAppModal closeModal={onDone} sourceAppId={appId} sourceAppName={appName} />);
+          return;
+        }
+
         const launchApp = async (): Promise<void> => {
-          await moonDeckAppLauncher.launchApp(appId, appName, AppType.MoonDeck);
+          if (nonSteamShortcut && helperAppId !== null) {
+            await moonDeckAppLauncher.launchApp(helperAppId, appName, AppType.GameStream, appId);
+          } else {
+            await moonDeckAppLauncher.launchApp(appId, appName, AppType.MoonDeck);
+          }
           await sleep(1000);
         };
 

--- a/src/contexts/moondeckcontext.tsx
+++ b/src/contexts/moondeckcontext.tsx
@@ -3,6 +3,7 @@
 import { AppSyncState } from "../lib/appsyncstate";
 import { ConnectivityManager } from "../lib/connectivitymanager";
 import { ExternalAppShortcuts } from "../lib/externalappshortcuts";
+import { LinkedAppShortcuts } from "../lib/linkedappshortcuts";
 import { MoonDeckAppLauncher } from "../lib/moondeckapplauncher";
 import { MoonDeckAppShortcuts } from "../lib/moondeckappshortcuts";
 import { SettingsManager } from "../lib/settingsmanager";
@@ -11,6 +12,7 @@ import { createContext } from "react";
 export interface MoonDeckContextType {
   appSyncState: AppSyncState;
   moonDeckAppShortcuts: MoonDeckAppShortcuts;
+  linkedAppShortcuts: LinkedAppShortcuts;
   externalAppShortcuts: ExternalAppShortcuts;
   settingsManager: SettingsManager;
   connectivityManager: ConnectivityManager;
@@ -27,10 +29,11 @@ export function getDefaultContext(makeNew = false): MoonDeckContextType {
   if (makeNew) {
     context.appSyncState = new AppSyncState();
     context.moonDeckAppShortcuts = new MoonDeckAppShortcuts(context.appSyncState);
+    context.linkedAppShortcuts = new LinkedAppShortcuts();
     context.settingsManager = new SettingsManager();
     context.connectivityManager = new ConnectivityManager(context.settingsManager);
     context.externalAppShortcuts = new ExternalAppShortcuts(context.appSyncState, context.connectivityManager.buddyProxy, context.settingsManager);
-    context.moonDeckAppLauncher = new MoonDeckAppLauncher(context.appSyncState, context.settingsManager, context.moonDeckAppShortcuts, context.externalAppShortcuts, context.connectivityManager.commandProxy);
+    context.moonDeckAppLauncher = new MoonDeckAppLauncher(context.appSyncState, context.settingsManager, context.moonDeckAppShortcuts, context.linkedAppShortcuts, context.externalAppShortcuts, context.connectivityManager.commandProxy);
   }
   return context;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import { getDefaultContext } from "./contexts";
 import { sleep } from "@decky/ui";
 
 export default definePlugin(() => {
-  const { moonDeckAppShortcuts, externalAppShortcuts, settingsManager, connectivityManager, moonDeckAppLauncher } = getDefaultContext(true);
+  const { moonDeckAppShortcuts, linkedAppShortcuts, externalAppShortcuts, settingsManager, connectivityManager, moonDeckAppLauncher } = getDefaultContext(true);
   const routeManager = new RouteManager();
 
   let initializing = false;
@@ -30,6 +30,7 @@ export default definePlugin(() => {
 
         externalAppShortcuts.init(allAppDetails);
         moonDeckAppShortcuts.init(allAppDetails);
+        linkedAppShortcuts.init(allAppDetails);
         settingsManager.init();
         connectivityManager.init();
         moonDeckAppLauncher.init();
@@ -52,6 +53,7 @@ export default definePlugin(() => {
     moonDeckAppLauncher.deinit();
     connectivityManager.deinit();
     settingsManager.deinit();
+    linkedAppShortcuts.deinit();
     moonDeckAppShortcuts.deinit();
     externalAppShortcuts.deinit();
   };

--- a/src/lib/externalappshortcuts.ts
+++ b/src/lib/externalappshortcuts.ts
@@ -1,6 +1,6 @@
 import { AppType, EnvVars, addAppsToCollection, addShortcut, checkExecPathMatch, getAppDetailsForAppIds, getAppStoreEx, getMoonDeckRunPath, getOrCreateCollection, isMoonDeckShortcut, removeAppsFromCollection, removeShortcut, restartSteamClient, setAppLaunchOptions } from "./steamutils";
 import { HostSettings, SettingsManager } from "./settingsmanager";
-import { getEnvKeyValueString, makeEnvKeyValue } from "./envutils";
+import { getEnvKeyValueNumber, getEnvKeyValueString, makeEnvKeyValue } from "./envutils";
 import { AppDetails } from "@decky/ui/dist/globals/steam-client/App";
 import { AppSyncState } from "./appsyncstate";
 import { BehaviorSubject } from "rxjs";
@@ -149,6 +149,10 @@ export class ExternalAppShortcuts {
       }
 
       if (details.strLaunchOptions.includes(makeEnvKeyValue(EnvVars.AppType, AppType.GameStream))) {
+        if (getEnvKeyValueNumber(details.strLaunchOptions, EnvVars.LinkedSourceAppId) !== null) {
+          continue;
+        }
+
         const appType = AppType.GameStream;
         this.managedApps.set(details.unAppID, { appId: details.unAppID, appName: details.strDisplayName, appType, gameId: overview.gameid });
         addAppInfo(details, appType);

--- a/src/lib/linkedappshortcuts.ts
+++ b/src/lib/linkedappshortcuts.ts
@@ -1,0 +1,250 @@
+import { AppType, EnvVars, addShortcut, getAppStoreEx, removeShortcut as removeSteamShortcut, setAppHiddenState, setAppLaunchOptions } from "./steamutils";
+import { getEnvKeyValueNumber, getEnvKeyValueString, makeEnvKeyValue } from "./envutils";
+import { AppDetails } from "@decky/ui/dist/globals/steam-client/App";
+import { AppOverviewPatcher } from "./appoverviewpatcher";
+import BiMap from "ts-bidirectional-map";
+import { logger } from "./logger";
+
+function makeLaunchOptions(sourceAppId: number, targetName: string): string {
+  return [
+    makeEnvKeyValue(EnvVars.AppType, AppType.GameStream),
+    makeEnvKeyValue(EnvVars.AppName, targetName),
+    makeEnvKeyValue(EnvVars.LinkedSourceAppId, sourceAppId),
+    "%command%"
+  ].join(" ");
+}
+
+export interface LinkedAppShortcutInfo {
+  sourceAppId: number;
+  helperAppId: number;
+  sourceName: string;
+  targetName: string;
+}
+
+export class LinkedAppShortcuts {
+  private unobserveCallback: (() => void) | null = null;
+  private keyMapping: BiMap<number, number> | null = null;
+  private sourceNames = new Map<number, string>();
+  private targetNames = new Map<number, string>();
+  private readonly appOverviewPatcher = new AppOverviewPatcher({
+    rt_last_time_locally_played: (currentValue, newValue) =>
+      typeof currentValue !== "number" ||
+      (typeof newValue === "number" && newValue > currentValue)
+  });
+
+  private removeCachedHelper(helperAppId: number): void {
+    if (this.keyMapping === null) {
+      return;
+    }
+
+    let sourceAppId: number | null = null;
+    for (const candidate of this.targetNames.keys()) {
+      if (this.keyMapping.get(candidate) === helperAppId) {
+        sourceAppId = candidate;
+        break;
+      }
+    }
+
+    this.keyMapping.deleteValue(helperAppId);
+    this.appOverviewPatcher.removePair(helperAppId);
+
+    if (sourceAppId !== null) {
+      this.targetNames.delete(sourceAppId);
+    }
+  }
+
+  private initAppStoreObservable(): void {
+    const appStoreEx = getAppStoreEx();
+    if (appStoreEx === null) {
+      logger.error("appStoreEx is null!");
+      return;
+    }
+
+    this.unobserveCallback = appStoreEx.observe((change) => {
+      if (change.type !== "delete" || this.keyMapping?.hasValue(change.name) !== true) {
+        return;
+      }
+
+      this.removeCachedHelper(change.name);
+    });
+  }
+
+  init(allDetails: AppDetails[]): void {
+    this.initAppStoreObservable();
+    this.appOverviewPatcher.init();
+    this.keyMapping = new BiMap();
+    this.sourceNames = new Map(allDetails.map((details) => [details.unAppID, details.strDisplayName]));
+    this.targetNames.clear();
+
+    for (const details of allDetails) {
+      if (!details.strLaunchOptions.includes(
+        makeEnvKeyValue(EnvVars.AppType, AppType.GameStream)
+      )) {
+        continue;
+      }
+
+      const sourceAppId = getEnvKeyValueNumber(
+        details.strLaunchOptions,
+        EnvVars.LinkedSourceAppId
+      );
+      if (sourceAppId === null) {
+        continue;
+      }
+
+      const targetName = getEnvKeyValueString(
+        details.strLaunchOptions,
+        EnvVars.AppName
+      );
+      if (targetName === null) {
+        logger.error("Linked shortcut is missing its host app name!");
+        continue;
+      }
+
+      if (this.keyMapping.get(sourceAppId) !== undefined) {
+        logger.error("Duplicate linked shortcut for source app!");
+        continue;
+      }
+
+      this.keyMapping.set(sourceAppId, details.unAppID);
+      this.targetNames.set(sourceAppId, targetName);
+      this.appOverviewPatcher.addPair(details.unAppID, sourceAppId);
+    }
+  }
+
+  deinit(): void {
+    this.appOverviewPatcher.deinit();
+
+    if (this.unobserveCallback !== null) {
+      this.unobserveCallback();
+      this.unobserveCallback = null;
+    }
+
+    this.keyMapping = null;
+    this.sourceNames.clear();
+    this.targetNames.clear();
+  }
+
+  getId(sourceAppId: number): number | null {
+    if (this.keyMapping === null) {
+      logger.error("Linked shortcut manager is not ready yet!");
+      return null;
+    }
+
+    return this.keyMapping.get(sourceAppId) ?? null;
+  }
+
+  getSourceName(sourceAppId: number): string | null {
+    return this.sourceNames.get(sourceAppId) ?? null;
+  }
+
+  getEntries(): LinkedAppShortcutInfo[] {
+    if (this.keyMapping === null) {
+      return [];
+    }
+
+    const entries: LinkedAppShortcutInfo[] = [];
+
+    for (const [sourceAppId, targetName] of this.targetNames.entries()) {
+      const helperAppId = this.keyMapping.get(sourceAppId);
+      if (helperAppId === undefined) {
+        continue;
+      }
+
+      entries.push({
+        sourceAppId,
+        helperAppId,
+        sourceName: this.getSourceName(sourceAppId) ?? "Non-Steam shortcut",
+        targetName
+      });
+    }
+
+    return entries;
+  }
+
+  updateAppLaunchTimestamp(sourceAppId: number): void {
+    const helperAppId = this.getId(sourceAppId);
+    if (helperAppId !== null) {
+      this.appOverviewPatcher.tryUpdate(helperAppId);
+    }
+  }
+
+  async updateGameStreamShortcut(sourceAppId: number, targetName: string): Promise<boolean> {
+    if (this.keyMapping === null) {
+      logger.error("Linked shortcut manager is not ready yet!");
+      return false;
+    }
+
+    const helperAppId = this.keyMapping.get(sourceAppId);
+    if (helperAppId === undefined) {
+      logger.error("Linked shortcut does not exist for source app!");
+      return false;
+    }
+
+    if (!await setAppLaunchOptions(
+      helperAppId,
+      makeLaunchOptions(sourceAppId, targetName)
+    )) {
+      return false;
+    }
+
+    this.targetNames.set(sourceAppId, targetName);
+    return true;
+  }
+
+  async addGameStreamShortcut(
+    sourceAppId: number,
+    sourceName: string,
+    targetName: string,
+    execPath: string
+  ): Promise<number | null> {
+    if (this.keyMapping === null) {
+      logger.error("Linked shortcut manager is not ready yet!");
+      return null;
+    }
+
+    if (this.keyMapping.get(sourceAppId) !== undefined) {
+      logger.error("A linked shortcut already exists for the source app!");
+      return null;
+    }
+
+    const helperAppId = await addShortcut(sourceName, execPath);
+    if (helperAppId === null) {
+      logger.error("Failed to create linked shortcut!");
+      return null;
+    }
+
+    if (!await setAppLaunchOptions(
+      helperAppId,
+      makeLaunchOptions(sourceAppId, targetName)
+    )) {
+      logger.error("Failed to configure linked shortcut!");
+      await removeSteamShortcut(helperAppId);
+      return null;
+    }
+
+    if (!await setAppHiddenState(helperAppId, true)) {
+      logger.error("Failed to hide linked shortcut!");
+      await removeSteamShortcut(helperAppId);
+      return null;
+    }
+
+    this.keyMapping.set(sourceAppId, helperAppId);
+    this.sourceNames.set(sourceAppId, sourceName);
+    this.targetNames.set(sourceAppId, targetName);
+    this.appOverviewPatcher.addPair(helperAppId, sourceAppId);
+    return helperAppId;
+  }
+
+  async removeShortcut(helperAppId: number, fromSteamList = true): Promise<boolean> {
+    if (fromSteamList && !await removeSteamShortcut(helperAppId)) {
+      return false;
+    }
+
+    this.removeCachedHelper(helperAppId);
+    return true;
+  }
+
+  get initializing(): boolean {
+    return this.keyMapping === null;
+  }
+}

--- a/src/lib/moondeckapp.ts
+++ b/src/lib/moondeckapp.ts
@@ -52,7 +52,7 @@ async function getRunnerResult(): Promise<string | null> {
 }
 
 function getAppId(appData: MoonDeckAppData) {
-  return appData.moonDeckAppId ?? appData.steamAppId;
+  return appData.runnerAppId;
 }
 
 export interface SessionOptions {
@@ -61,6 +61,7 @@ export interface SessionOptions {
 
 export interface MoonDeckAppData {
   steamAppId: number;
+  runnerAppId: number;
   moonDeckAppId: number | null;
   name: string;
   appType: AppType;
@@ -77,10 +78,11 @@ export class MoonDeckAppProxy extends ReadonlySubject<MoonDeckAppData | null> {
     this.commandProxy = commandProxy;
   }
 
-  setApp(steamAppId: number, moonDeckAppId: number, name: string, appType: AppType, sessionOptions: SessionOptions): void {
+  setApp(steamAppId: number, runnerAppId: number, name: string, appType: AppType, sessionOptions: SessionOptions): void {
     this.subject.next({
       steamAppId,
-      moonDeckAppId: appType === AppType.MoonDeck ? moonDeckAppId : null,
+      runnerAppId,
+      moonDeckAppId: appType === AppType.MoonDeck ? runnerAppId : null,
       name,
       appType,
       redirected: false,

--- a/src/lib/moondeckapplauncher.ts
+++ b/src/lib/moondeckapplauncher.ts
@@ -1,12 +1,13 @@
 import { AppStartResult, AppType, ControllerConfigOption, EnvVars, checkExecPathMatch, getAppDetails, getAudioDevices, getCurrentDisplayModeString, getCurrentUserSteamId, getDisplayIdentifiers, getMoonDeckRunPath, getSystemNetworkStore, launchApp, registerForGameLaunchIntercept, registerForGameLifetime, registerForSuspendNotifications, setAppHiddenState, setAppLaunchOptions, setAppResolutionOverride, setOverrideResolutionForInternalDisplay, setShortcutName } from "./steamutils";
 import { ControllerConfigValues, Dimension, HostResolution, HostSettings, SettingsManager } from "./settingsmanager";
 import { Subscription, pairwise } from "rxjs";
-import { getEnvKeyValueString, makeEnvKeyValue } from "./envutils";
+import { getEnvKeyValueNumber, getEnvKeyValueString, makeEnvKeyValue } from "./envutils";
 import { AppDetails } from "@decky/ui/dist/globals/steam-client/App";
 import { AppSyncState } from "./appsyncstate";
 import { CommandProxy } from "./commandproxy";
 import { EThirdPartyControllerConfiguration } from "@decky/ui/dist/globals/steam-client/Input";
 import { ExternalAppShortcuts } from "./externalappshortcuts";
+import { LinkedAppShortcuts } from "./linkedappshortcuts";
 import { MoonDeckAppProxy } from "./moondeckapp";
 import { MoonDeckAppShortcuts } from "./moondeckappshortcuts";
 import { call } from "@decky/api";
@@ -87,6 +88,11 @@ function getLaunchOptionsString(currentValue: string, appId: number, appType: Ap
     }
 
     launchOptions.push(makeEnvKeyValue(EnvVars.AppName, appNameFromOptions));
+
+    const linkedSourceAppId = getEnvKeyValueNumber(currentValue, EnvVars.LinkedSourceAppId);
+    if (linkedSourceAppId !== null) {
+      launchOptions.push(makeEnvKeyValue(EnvVars.LinkedSourceAppId, linkedSourceAppId));
+    }
   } else {
     const appIdFromOptions = getEnvKeyValueString(currentValue, EnvVars.SteamAppId);
     if (appIdFromOptions === null) {
@@ -244,7 +250,11 @@ export class MoonDeckAppLauncher {
     this.subscription = new Subscription();
     this.subscription.add(this.moonDeckApp.asObservable().pipe(pairwise()).subscribe(([prev, next]) => {
       if (prev !== null && next === null) {
-        this.moonDeckAppShortcuts.updateAppLaunchTimestamp(prev.steamAppId);
+        if (prev.appType === AppType.MoonDeck) {
+          this.moonDeckAppShortcuts.updateAppLaunchTimestamp(prev.steamAppId);
+        } else if (this.linkedAppShortcuts.getId(prev.steamAppId) !== null) {
+          this.linkedAppShortcuts.updateAppLaunchTimestamp(prev.steamAppId);
+        }
       }
     }));
   }
@@ -275,6 +285,7 @@ export class MoonDeckAppLauncher {
     private readonly appSyncState: AppSyncState,
     private readonly settingsManager: SettingsManager,
     private readonly moonDeckAppShortcuts: MoonDeckAppShortcuts,
+    private readonly linkedAppShortcuts: LinkedAppShortcuts,
     private readonly externalAppShortcuts: ExternalAppShortcuts,
     readonly commandProxy: CommandProxy
   ) {
@@ -307,8 +318,13 @@ export class MoonDeckAppLauncher {
     }
   }
 
-  async launchApp(appId: number, appName: string, appType: AppType): Promise<void> {
-    if (this.moonDeckAppShortcuts.initializing || this.externalAppShortcuts.initializing) {
+  async launchApp(
+    appId: number,
+    appName: string,
+    appType: AppType,
+    sourceAppId: number = appId
+  ): Promise<void> {
+    if (this.moonDeckAppShortcuts.initializing || this.linkedAppShortcuts.initializing || this.externalAppShortcuts.initializing) {
       logger.toast("Plugin is still initializing...");
       return;
     }
@@ -412,7 +428,7 @@ export class MoonDeckAppLauncher {
         };
       }
 
-      this.moonDeckApp.setApp(appId, details.unAppID, appName, appType, sessionOptions);
+      this.moonDeckApp.setApp(sourceAppId, details.unAppID, appName, appType, sessionOptions);
       await this.moonDeckApp.clearRunnerResult();
 
       const launchResult = await launchApp(details.unAppID, hostSettings.runnerTimeouts.steamLaunch * 1000);

--- a/src/lib/steamutils.ts
+++ b/src/lib/steamutils.ts
@@ -14,6 +14,7 @@ export enum EnvVars {
   SteamAppId = "MOONDECK_STEAM_APP_ID",
   SteamUserId = "MOONDECK_STEAM_USER_ID",
   AppName = "MOONDECK_APP_NAME",
+  LinkedSourceAppId = "MOONDECK_LINKED_SOURCE_APP_ID",
   Python = "MOONDECK_PYTHON"
 }
 
@@ -67,6 +68,10 @@ export async function getAllNonSteamAppDetails(): Promise<AppDetails[] | null> {
   }
 
   return await getAppDetailsForAppIds(appIds);
+}
+
+export function isNonSteamShortcut(appType: number): boolean {
+  return appType === 1073741824;
 }
 
 export function isAppTypeSupported(appType: number): boolean {

--- a/src/routes/libaryapp.tsx
+++ b/src/routes/libaryapp.tsx
@@ -57,7 +57,13 @@ function patchLibraryApp(route: string): RoutePatch {
             return ret;
           }
 
-          if (moonDeckAppLauncher.moonDeckApp.value?.moonDeckAppId === appId) {
+          const activeMoonDeckApp = moonDeckAppLauncher.moonDeckApp.value;
+          const isTechnicalRunner =
+            activeMoonDeckApp !== null &&
+            activeMoonDeckApp.runnerAppId === appId &&
+            activeMoonDeckApp.steamAppId !== appId;
+
+          if (activeMoonDeckApp?.moonDeckAppId === appId || isTechnicalRunner) {
             // We are suppressing the navigation to custom shortcut ONLY if this happens after
             // launch via the moondeck button and we MUST navigate back ONLY once
             if (moonDeckAppLauncher.moonDeckApp.canRedirect()) {

--- a/src/routes/moondeck.tsx
+++ b/src/routes/moondeck.tsx
@@ -6,6 +6,7 @@ import { GameSessionView } from "../components/gamesessionview";
 import { GameStreamAppsView } from "../components/gamestreamappsview";
 import { HostInfoView } from "../components/hostinfoview";
 import { HostSelectionView } from "../components/hostselectionview";
+import { LinkedNonSteamAppsView } from "../components/linkednonsteamappsview";
 import { MoonDeckAppsView } from "../components/moondeckappsview";
 import { MoonlightSettingsView } from "../components/moonlightsettingsview";
 import { NonSteamAppsView } from "../components/nonsteamappsview/nonsteamappsview";
@@ -87,6 +88,12 @@ const MoonDeckRouter: FC<object> = () => {
           title: "GameStream Apps",
           content: <GameStreamAppsView />,
           route: "/moondeck/gamestream-apps",
+          visible: true
+        },
+        {
+          title: "Linked Non-Steam Apps",
+          content: <LinkedNonSteamAppsView />,
+          route: "/moondeck/linked-non-steam-apps",
           visible: true
         },
         {


### PR DESCRIPTION
Implements the functionality discussed in #120 and also addresses the use case reported in #149.

## Summary

This adds support for linking an existing Non-Steam shortcut to a GameStream host app.

The existing Non-Steam shortcut remains the single visible library entry:

- Normal **Play** continues to launch the local shortcut.
- The **MoonDeck** button launches the linked host app.
- MoonDeck does not need to create a second visible library entry for the linked app.

Links can be created and changed from the MoonDeck launch button and managed from a new **Linked Non-Steam Apps** settings page, where they can also be changed or removed.

## Implementation

The implementation keeps the visible source shortcut separate from the technical shortcut used for the MoonDeck launch.

A hidden GameStream helper shortcut stores the link to the source Non-Steam shortcut. These helper shortcuts are also used to reconstruct the mappings when MoonDeck initializes.

This avoids adding a new settings schema or backend persistence format for the links.

Linked helper shortcuts are excluded from the normal external-app shortcut management so that they do not appear as duplicate visible entries.

Launch handling keeps both identities available:

- the visible source app, used for the library page and source-app state;
- the technical runner/helper app, used for the streamed launch.

This also ensures that navigation returns to the original visible shortcut after launching.

## UI

A new full settings page is added:

**GameStream Apps → Linked Non-Steam Apps → Non-Steam Apps**

The page shows the existing links and allows:

- changing a link;
- unlinking an app;
- confirming or cancelling unlink operations.

Link management is intentionally kept out of the Quick Access menu.

## Testing

I manually tested the following behavior:

- linking an existing Non-Steam shortcut;
- restoring the link after initialization/restart;
- streamed launch through the MoonDeck button;
- normal local launch through Steam Play;
- multiple linked shortcuts;
- changing an existing link;
- unlinking and relinking;
- no duplicate visible library entries;
- navigation back to the visible source shortcut after launch;
- existing standard MoonDeck/Steam app behavior;
- full reboot/restart persistence.

The frontend also passes ESLint and the Rollup build.

I am opening this as a **draft** because the implementation touches shortcut identity and launch handling, and I would particularly appreciate feedback on the architecture before doing broader testing.

### Development transparency

This contribution was developed with substantial assistance from AI tools.

I am not a software developer and do not claim programming expertise. I defined the desired behavior, performed the builds and deployments, and manually tested the resulting functionality on my own systems. The implementation itself was developed with AI assistance and should be reviewed accordingly.

The complete source code is provided so that users and maintainers can inspect the implementation before deciding whether to run it on their systems.